### PR TITLE
Show error using proper HTTP status and mimetype

### DIFF
--- a/apoiase/app.py
+++ b/apoiase/app.py
@@ -1,7 +1,7 @@
 import json
 
 import requests
-from flask import Flask, jsonify, render_template
+from flask import Flask, jsonify
 from flask_cors import CORS
 
 import config
@@ -15,7 +15,9 @@ CORS(app)
 @app.route('/')
 def home():
     if not config.APOIASE_URL:
-        return render_template('no_env_variable.html')
+        error = dict(error='Apoia.se URL not set as env variable!')
+        return jsonify(error), 500
+
     response = requests.get(config.APOIASE_URL)
     if response.status_code == 200:
         page = json.loads(response.text)

--- a/apoiase/templates/no_env_variable.html
+++ b/apoiase/templates/no_env_variable.html
@@ -1,8 +1,0 @@
-<html>
-  <head>
-    <title>Apoia.se Scrapper</title>
-  </head>
-  <body>
-    <p>Apoia.se URL not set as env variable!</p>
-  </body>
-</html>


### PR DESCRIPTION
Error was using HTTP status 200 and HTML — as this is a JSON API, maybe a JSON formatted error it better.