### PR TITLE
Use Flask native CLI in development

### DIFF
--- a/apoiase/README.md
+++ b/apoiase/README.md
@@ -5,7 +5,9 @@ A [Flask][1] app for scrapping [Apoia.se][2] supporters names.
 We use [environment variables][3] to set the Apoia.se URL for this scrapper.
 You can set yours by using:
 
-`export APOIASE_URL='https://apoia.se/api/v1/users/serenata?format=json'`
+```console
+$ export APOIASE_URL='https://apoia.se/api/v1/users/serenata?format=json'
+```
 
 or any other Apoia.se API URL.
 
@@ -19,26 +21,45 @@ gives support to manage Python's virtual environments.
 
 2. Create your Python 3 environment with:
 
-`virtualenv -p python3 apoiase`
+```console
+$ virtualenv -p python3 apoiase
+```
 
 3. Activate your environment using:
 
-`source apoiase/bin/activate`
+```console
+$ source apoiase/bin/activate
+```
 
 4. Run the setup:
 
-`python setup`
+```console
+$ python setup
+```
 
 #### Without virtual
 If you want, you can only install the dependencies in your computer
 by running:
 
-`python3 setup`
+```console
+$ python3 setup
+```
 
 ### Running the app
-To check your work you can run locally the app on your terminal run the following:
+Following [Flask's new CLI][5] we need a environment variable with our app — 
+optionally you can set the debug mode too:
 
-`python3 app.py`
+```console
+$ export FLASK_APP=app.py
+$ export FLASK_DEBUG=1
+```
+
+To start the server you can run the app locally on your terminal:
+
+```console
+$ cd apoiase/
+$ flask run
+```
 
 and after that open a browser and access:
 
@@ -52,3 +73,4 @@ supporters names.
 [2]: http://flask.pocoo.org/
 [3]: https://www.digitalocean.com/community/tutorials/how-to-read-and-set-environmental-and-shell-variables-on-a-linux-vps
 [4]: https://virtualenv.pypa.io/
+[5]: http://flask.pocoo.org/docs/0.12/cli/

--- a/apoiase/app.py
+++ b/apoiase/app.py
@@ -29,7 +29,3 @@ def home():
 
 def serializer(apoiase_users):
     return dict(name=apoiase_users.get('_id').get('name'))
-
-
-if __name__ == '__main__':
-    app.run()


### PR DESCRIPTION
Since version 0.12 Flask documentation recommends running the app (in development) with its native runner: [`flask run`](http://flask.pocoo.org/docs/0.12/cli/). This is what this PR is about ; )